### PR TITLE
include html templates into bundled python package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include README.rst
 recursive-include hr_management/static *
-recursive-include hr_management/templates
+recursive-include hr_management *.html


### PR DESCRIPTION
The old code worked fine for under devstack, but when installing on a production instance, Django couldn't find the appropriate templates. 

We also might want to consider including other file types in the MANIFEST, like edX does here: 

https://github.com/edx/cookiecutter-django-app/blob/master/%7B%7Bcookiecutter.repo_name%7D%7D/MANIFEST.in